### PR TITLE
#54 Refactor : 유저 즐겨찾기 키워드 API 응답 변경

### DIFF
--- a/controllers/chartController2.js
+++ b/controllers/chartController2.js
@@ -22,7 +22,7 @@ exports.getChart = async (req, res) => {
     const { start, end } = getDateRange()
     const baseUrl = `https://openapivts.koreainvestment.com:29443/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice?FID_COND_MRKT_DIV_CODE=J&FID_INPUT_ISCD=${stock_code}&FID_INPUT_DATE_1=${start}&FID_INPUT_DATE_2=${end}&FID_PERIOD_DIV_CODE=${chart_period}&FID_ORG_ADJ_PRC=0`
     const token =
-      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0b2tlbiIsImF1ZCI6Ijg2NGRkMWEzLWQ5ZGYtNGM3My04N2EzLTM0OWExYjQyZGE0ZiIsInByZHRfY2QiOiIiLCJpc3MiOiJ1bm9ndyIsImV4cCI6MTczMjY2MzI1NSwiaWF0IjoxNzMyNTc2ODU1LCJqdGkiOiJQU0lvaXVTUDAyNU40VkpRMzBzWm96eE5sS0hOaFFPV2RzNGEifQ.KIpBQHAhvVNVHPxBUVvgZOas3Fkrwk2SdBl_BtzM52xLYtbNB-d9m9opnQsddFOnnq2KLRer3sWgLZVUAHMv2A'
+      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0b2tlbiIsImF1ZCI6IjBjMTJkYTVlLWFmNGMtNDE2MC05ZTZkLWE5ZDVlY2Y1MmE2NSIsInByZHRfY2QiOiIiLCJpc3MiOiJ1bm9ndyIsImV4cCI6MTczMjc0NDgwMSwiaWF0IjoxNzMyNjU4NDAxLCJqdGkiOiJQU0lvaXVTUDAyNU40VkpRMzBzWm96eE5sS0hOaFFPV2RzNGEifQ.huSWEVbi_ZDwxWvUaOUceKu0-1tlChpxOscLOG6Ay2OaGoNcnG9V8IPz-aPjxuGRsECk03nb8YLJw1sl4teMlg'
 
     const headers = {
       'Content-Type': 'application/json; charset=utf-8',

--- a/controllers/userKeywordController.js
+++ b/controllers/userKeywordController.js
@@ -1,3 +1,4 @@
+const Keyword = require('../models/Keyword')
 const User_Keyword = require('../models/User_Keyword') // 모델 경로 주의 (대소문자 확인)
 const sequelize = require('sequelize')
 
@@ -46,22 +47,40 @@ exports.deleteUserKeyword = async (req, res) => {
   }
 }
 
-// 특정 user의 user_keyword 조회
+// // 특정 user의 user_keyword 조회
 exports.getUserKeyword = async (req, res) => {
-  const user_id = req.user.userId
+  const user_id = req.user.userId;
   try {
-    // 특정 사용자에 대한 모든 키워드 조회
-    const userKeywords = await User_Keyword.findAll({
-      where: {
-        user_id,
-      },
-    })
-    res.status(200).json({ userKeywords })
+    // user_keyword 테이블에서 특정 사용자의 키워드 정보 조회
+    const userKeywordList = await User_Keyword.findAll({
+      where: { user_id },
+      raw: true,
+    });    
+
+    // 각 userKeyword에 대해 가장 큰 keyword_id를 가져옵니다.
+    const userKeywords = await Promise.all(userKeywordList.map(async (userKeyword) => {
+      const keyword = await Keyword.findOne({
+        where: { keyword: userKeyword.keyword },  // 동일한 keyword를 기준으로
+        attributes: [[sequelize.fn('MAX', sequelize.col('id')), 'keyword_id']],  // 가장 큰 id를 가져옵니다.
+        raw: true,
+      });
+
+      // userKeyword에 keyword_id를 추가하여 반환
+      return {
+        ...userKeyword,
+        keyword_id: keyword ? keyword.keyword_id : null,  // 가장 큰 id를 keyword_id로 추가
+      };
+    }));
+
+    console.log(userKeywords)
+    
+    // userKeyword와 가장 큰 keyword_id를 함께 응답
+    res.status(200).json({ userKeywords });
   } catch (error) {
-    console.error('사용자 키워드 조회 오류:', error)
-    res.status(500).json({ error: '사용자 키워드 조회에 실패했습니다.' })
+    console.error('사용자 키워드 조회 오류:', error);
+    res.status(500).json({ error: '사용자 키워드 조회에 실패했습니다.' });
   }
-}
+};
 
 //user_keyword의 알림 상태 업데이트
 exports.updateUserKeyword = async (req, res) => {


### PR DESCRIPTION
유저 즐겨찾기 키워드 API 응답 변경
- 유저 즐겨찾기 목록을 조회할 때 keyword_id도 조회하도록 변경
```javascript
exports.getUserKeyword = async (req, res) => {
  const user_id = req.user.userId;
  try {
    // user_keyword 테이블에서 특정 사용자의 키워드 정보 조회
    const userKeywordList = await User_Keyword.findAll({
      where: { user_id },
      raw: true,
    });    

    // 각 userKeyword에 대해 가장 큰 keyword_id를 가져옵니다.
    const userKeywords = await Promise.all(userKeywordList.map(async (userKeyword) => {
      const keyword = await Keyword.findOne({
        where: { keyword: userKeyword.keyword },  // 동일한 keyword를 기준으로
        attributes: [[sequelize.fn('MAX', sequelize.col('id')), 'keyword_id']],  // 가장 큰 id를 가져옵니다.
        raw: true,
      });

      // userKeyword에 keyword_id를 추가하여 반환
      return {
        ...userKeyword,
        keyword_id: keyword ? keyword.keyword_id : null,  // 가장 큰 id를 keyword_id로 추가
      };
    }));

    console.log(userKeywords)
    
    // userKeyword와 가장 큰 keyword_id를 함께 응답
    res.status(200).json({ userKeywords });
  } catch (error) {
    console.error('사용자 키워드 조회 오류:', error);
    res.status(500).json({ error: '사용자 키워드 조회에 실패했습니다.' });
  }
};
``` 